### PR TITLE
Fix incorrect flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ List ROM files in a given directory. By default, output is in a human-readable t
 
 #### Options
 
-* `-f`, `--format` Defaults to `table` but can also be `text`, `json`, `csv`, `tab`, `xml`
+* `-o`, `--output` Defaults to `table` but can also be `text`, `json`, `csv`, `tab`, `xml`
 * `-c`, `--columns` Defaults to most useful columns. Can be a comma-separated list, or specified multiple times.
 
 **Available columns**


### PR DESCRIPTION
I spent way too long figuring this out, heh.

Remove mentions of the -f flag and replace with the new (I'm assuming) -o flag.

This should confuse users less.

The output is actually mentioned later in the README, but I was misunderstanding.

Hopefully this helps. 😀